### PR TITLE
Make publish command useful

### DIFF
--- a/source/command/publish.js
+++ b/source/command/publish.js
@@ -41,7 +41,6 @@ function publish (_, { files }) {
 }
 
 publish.messages = {
-  start: 'The project is being published',
   end: 'Project published'
 }
 


### PR DESCRIPTION
In case of `start` message for publish command, git's suggests for username and password just blink in console and `listr`'s update hide them. So it looks like infinite publish for user. He can print the username and password still, but it isn't user-friendly.
Removing `start` command allows user to see git's authentication dialogue.