### PR TITLE
Change paths for themes to org (fix #21)

### DIFF
--- a/source/command/create.js
+++ b/source/command/create.js
@@ -80,7 +80,7 @@ async function create ({ cwd }, { directory: folderName = 'slides' }) {
       title: 'Installing dependencies',
       task: () => Promise.all([
         installDependencies(directory, ['shower-cli'], 'save-dev'),
-        installDependencies(directory, ['shower-core', `shower-${options.theme}`])
+        installDependencies(directory, ['shower-core', `@shower/${options.theme}`])
       ])
     }
   ])

--- a/source/lib/presentation.js
+++ b/source/lib/presentation.js
@@ -14,7 +14,7 @@ const defaultFiles = [
 function loadPresentationFiles (files = defaultFiles) {
   const shower = vfs.src(files)
     .pipe(replace(
-      /(<link rel="stylesheet" href=")(node_modules\/shower-)([^/]*)\/(.*\.css">)/g,
+      /(<link rel="stylesheet" href=")(node_modules\/@shower\/)([^/]*)\/(.*\.css">)/g,
       '$1shower/themes/$3/$4', { skipBinary: true }
     ))
     .pipe(replace(
@@ -34,7 +34,7 @@ function loadPresentationFiles (files = defaultFiles) {
   const material = vfs.src([
     '**', '!package.json'
   ], {
-    cwd: 'node_modules/shower-material'
+    cwd: 'node_modules/@shower/material'
   })
     .pipe(rename((path) => {
       path.dirname = 'shower/themes/material/' + path.dirname
@@ -43,7 +43,7 @@ function loadPresentationFiles (files = defaultFiles) {
   const ribbon = vfs.src([
     '**', '!package.json'
   ], {
-    cwd: 'node_modules/shower-ribbon'
+    cwd: 'node_modules/@shower/ribbon'
   })
     .pipe(rename((path) => {
       path.dirname = 'shower/themes/ribbon/' + path.dirname

--- a/templates/presentation/index.html
+++ b/templates/presentation/index.html
@@ -4,7 +4,7 @@
     <title>Shower Presentation Engine</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href="node_modules/shower-<%= theme %>/styles/styles.css">
+    <link rel="stylesheet" href="node_modules/@shower/<%= theme %>/styles/styles.css">
     <style>
         .shower {
             --slide-ratio: calc(<%= ratio %>);


### PR DESCRIPTION
Went through the files looking for possible places for paths to be used.

Haven’t tested locally though, because I’m not sure how exactly.