### PR TITLE
Make package.json private

### DIFF
--- a/templates/presentation/package.json
+++ b/templates/presentation/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "scripts": {
     "pdf": "shower pdf",
     "serve": "shower serve",


### PR DESCRIPTION
Otherwise it gives warnings during installation:

```sh
$ npm i

npm WARN intro No description
npm WARN intro No repository field.
npm WARN intro No license field.
```

You don’t need to have those fields for a private package. In fact, every package.json should be `private` unless it’s a package.