### PR TITLE
Rename prepare to bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,8 +66,8 @@ Files specified in files are considered to be part of the presentation
 
 ## 0.2.0-0
 * Added a check on the existence of the presentation
-* Add the prepare and archive tasks to readme
-* Created the prepared and archive tasks
+* Add the bundle and archive tasks to readme
+* Created the bundled and archive tasks
 * Wrote a new mechanism for creating a presentation
 * Added exit codes
 * Upgrade error handling in pdf

--- a/core/command/__tests__/bundle.test.js
+++ b/core/command/__tests__/bundle.test.js
@@ -1,7 +1,7 @@
-const { handler: prepare, messages } = require('../prepare')
+const { handler: bundle, messages } = require('../bundle')
 
 it('Must be function', () => {
-  expect(typeof prepare).toBe('function')
+  expect(typeof bundle).toBe('function')
 })
 
 it('Messages must provided "start" and "end" messages', () => {

--- a/core/command/bundle.js
+++ b/core/command/bundle.js
@@ -42,7 +42,7 @@ function builder (yargs) {
 
 function messages ({ output }) {
   return {
-    start: 'Project preparation in progress',
+    start: 'Project bundling in progress',
     end: chalk`Project bundled in {bold ${output}} dir`
   }
 }

--- a/core/command/bundle.js
+++ b/core/command/bundle.js
@@ -28,8 +28,8 @@ function builder (yargs) {
       output: {
         alias: 'o',
         type: 'string',
-        default: 'prepared',
-        describe: 'In which folder will the prepared presentation be written'
+        default: 'bundled',
+        describe: 'In which folder will the bundled presentation be written'
       },
       files: {
         alias: 'f',
@@ -43,7 +43,7 @@ function builder (yargs) {
 function messages ({ output }) {
   return {
     start: 'Project preparation in progress',
-    end: chalk`Project prepared in {bold ${output}} dir`
+    end: chalk`Project bundled in {bold ${output}} dir`
   }
 }
 

--- a/core/index.js
+++ b/core/index.js
@@ -63,8 +63,8 @@ const commandsList = {
     requireProject: true
   },
 
-  prepare: {
-    command: 'prepare',
+  bundle: {
+    command: 'bundle',
     describe: 'Gather the necessary files in a separate folder',
     requireProject: true
   },

--- a/core/lib/presentation.js
+++ b/core/lib/presentation.js
@@ -6,7 +6,7 @@ const replace = require('gulp-replace')
 const defaultFiles = [
   '**',
   '!node_modules{,/**}',
-  '!prepared{,/**}',
+  '!bundled{,/**}',
   '!package.json',
   '!package-lock.json'
 ]

--- a/readme.md
+++ b/readme.md
@@ -69,16 +69,16 @@ Options:
 ```
 
 
-**`$ shower prepare` - Gather the necessary files in a separate folder**
+**`$ shower bundle` - Gather the necessary files in a separate folder**
 
 ```
 Options:
-  --output, -o   In which folder will the prepared presentation be written
-                                                  [string] [default: "prepared"]
+  --output, -o   In which folder will the bundled presentation be written
+                                                  [string] [default: "bundled"]
   --files, -f    List of files that will get the build                   [array]
 ```
 
-**`$ shower archive` - Create an archive of the prepared presentation**
+**`$ shower archive` - Create an archive of the bundled presentation**
 
 ```
 Options:

--- a/templates/presentation/package.json
+++ b/templates/presentation/package.json
@@ -3,7 +3,7 @@
     "pdf": "shower pdf",
     "serve": "shower serve",
     "archive": "shower archive",
-    "prepare": "shower prepare",
+    "bundle": "shower bundle",
     "publish": "shower publish"
   }
 }


### PR DESCRIPTION
Otherwise it runs `prepare` on every `npm install` since it’s a [life cycle script](https://docs.npmjs.com/cli/v7/using-npm/scripts#life-cycle-scripts) like `start` or `test`.

```
$ npm i

> undefined prepare /Users/pepelsbey/Desktop/intro
> shower prepare

  ✔ Project preparation in progress
Project prepared in prepared dir 🎉
```

We could probably [choose a better name](https://www.thesaurus.com/browse/prepare), but I think it’s pretty close and well-known.